### PR TITLE
amend code in _info_window_html.erb to show categories

### DIFF
--- a/app/views/resources/_info_window.html.erb
+++ b/app/views/resources/_info_window.html.erb
@@ -1,5 +1,5 @@
   <h3><%= resource.name %></h3>
-  <h6><%= resource.category1 %></h6>
+  <h6><%= resource.categories.pluck(:name).join(',') %></h6>
   <p>Address: <br><%= resource.address %></p>
   <p>Contact: <br><%= resource.phone %></p>
   <p>Description: <br><%= resource.description %></p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87785320/148378872-154b16d4-0968-4031-b066-63dd8949f9d1.png)

Hey guys 
there was a category1 reference in the _info_window.html so I wrote some code to change it now that taggable gem is working so it shows. It's a bit ugly. We will probably end up changing this window anyway but merge it anyway. 