### PR TITLE
Location and category search

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -2,12 +2,15 @@ class ResourcesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index]
   before_action :set_locale
 
-def index
-  @tags = ActsAsTaggableOn::Tag.all
-  if params[:keywords]
-  @filters = params[:keywords]
-  @resources = @filters.nil? ? Resource.all : Resource.where(id: Resource.all.tagged_with(@filters, any: true).reject(&:blank?).map(&:id))
+  def index
+    @tags = ActsAsTaggableOn::Tag.all
+    @filters = params[:keywords]
 
+    if @filters.nil? || !params[:keywords]
+      @resources = Resource.all
+    else
+      @resources = Resource.where(id: Resource.all.tagged_with(@filters, any: true).reject(&:blank?).map(&:id))
+    end
     # if params[:query].present?
     #   @resources = Resource.search(params[:query])
 
@@ -27,8 +30,7 @@ def index
     #     info_window: render_to_string(partial: "info_window", locals: { resource: resource }),
     #   }
     #   end
-    end
-    @resources = Resource.all
+    # @resources = Resource.all
   end
 
 
@@ -36,19 +38,18 @@ def index
     @resource = Resource.new
   end
 
-    def create
-      @resource = Resource.new(resource_params)
-      @resource.user = current_user
-      if @resource.valid?
-        @resource.save
-        redirect_to resource_path(@resource)
-      else
-        render :new
-      end
+  def create
+    @resource = Resource.new(resource_params)
+    @resource.user = current_user
+    if @resource.valid?
+      @resource.save
+      redirect_to resource_path(@resource)
+    else
+      render :new
     end
-
-    def resource_params
-      params.require(:resource).permit(:name, :description, :address, :website, :phone, :state, :email, :status,:category_list, :user_id)
-    end
-
   end
+
+  def resource_params
+    params.require(:resource).permit(:name, :description, :address, :website, :phone, :state, :email, :status,:category_list, :user_id)
+  end
+end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -3,26 +3,32 @@ class ResourcesController < ApplicationController
   before_action :set_locale
 
 def index
-    if params[:query].present?
-      @resources = Resource.search(params[:query])
+  @tags = ActsAsTaggableOn::Tag.all
+  if params[:keywords]
+  @filters = params[:keywords]
+  @resources = @filters.nil? ? Resource.all : Resource.where(id: Resource.all.tagged_with(@filters, any: true).reject(&:blank?).map(&:id))
 
-        @markers = @resources.geocoded.map do |resource|
-      {
-        lat: resource.latitude,
-        lng: resource.longitude,
-        info_window: render_to_string(partial: "info_window", locals: { resource: resource }),
-      }
+    # if params[:query].present?
+    #   @resources = Resource.search(params[:query])
+
+    #     @markers = @resources.geocoded.map do |resource|
+    #   {
+    #     lat: resource.latitude,
+    #     lng: resource.longitude,
+    #     info_window: render_to_string(partial: "info_window", locals: { resource: resource }),
+    #   }
+    # end
+    # else
+    #   @resources = Resource.all
+    #      @markers = @resources.geocoded.map do |resource|
+    #   {
+    #     lat: resource.latitude,
+    #     lng: resource.longitude,
+    #     info_window: render_to_string(partial: "info_window", locals: { resource: resource }),
+    #   }
+    #   end
     end
-    else
-      @resources = Resource.all
-         @markers = @resources.geocoded.map do |resource|
-      {
-        lat: resource.latitude,
-        lng: resource.longitude,
-        info_window: render_to_string(partial: "info_window", locals: { resource: resource }),
-      }
-      end
-    end
+    @resources = Resource.all
   end
 
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -19,8 +19,4 @@ class Resource < ApplicationRecord
                 any_word: true
       }
     }
-
-  # include AlgoliaSearch
-  # algoliasearch do;  end
-
 end

--- a/app/views/resources/_search_banner.html.erb
+++ b/app/views/resources/_search_banner.html.erb
@@ -1,51 +1,24 @@
 <div class="container">
   <div id="seach-banner">
     <div class= "container flex m-4">
-      <%= form_tag resources_path, method: :get do %>
-        <%= text_field_tag :query,
-          params[:query],
-          class: "form-control",
-          placeholder: t("Search By City or Resource") %>
-      <%= submit_tag t("Search"), class: "btn btn-primary" %>
-      <% end %>
     </div>
 
-
-
-<%# @resources.each do |resource| %>
-<%#= raw resource.category_list.map { |t| link_to t, resources_url(t) }.join(', ') %>
-      <%# end %>
-  <%# </div> %>
-
-
 <div class="categories">
-    <h3>Categories</h3>
-      <%= simple_form_for :search, url: resources_path, method: "GET" do |f| %>
-        <% @tags.each do |tag|  %>
-          <div>
-            <%= check_box_tag "keywords[]", tag.name, @selected_tag.present? ? @selected_tag.include?(tag.name) : '' %>
-            <%= tag.name %>
-          </div>
-        <% end %>
-        <%= f.submit "Search", class: "btn btn-primary" %>
-          <%= link_to "Reset", resources_path  %>
-        <% end %>
-
+  <h3>Categories</h3>
+  <%= simple_form_for :search, url: resources_path, method: "GET" do |f| %>
+    <%= text_field_tag :query,
+      params[:query],
+      class: "form-control",
+      placeholder: t("Search By City or Resource") %>
+    <div class="d-flex justify-content-between align-items-center">
+      <% @tags.each do |tag|  %>
+        <div>
+          <%= check_box_tag "keywords[]", tag.name, params[:keywords].present? ? params[:keywords].include?(tag.name) : false  %>
+          <%= tag.name %>
+        </div>
+      <% end %>
+    </div>
+    <%= f.submit "Search", class: "btn btn-primary" %>
+    <%= link_to "Reset", resources_path  %>
+  <% end %>
   </div>
-
-
-
-
-
-
-    <%#= simple_form_for @resources do |f| %>
-    <%#= f.input :categories,
-              as: :radio_buttons,
-              collection_wrapper_category: 'div',
-              collection_wrapper_class: 'category-wrapper',
-              item_wrapper_class: 'category-item',
-              input_html: {class: 'category-selector'},
-              collection: Snippet::CATEGORIES %>
-    <%# end %>
-  <%# </div>
-</div> %>

--- a/app/views/resources/_search_banner.html.erb
+++ b/app/views/resources/_search_banner.html.erb
@@ -10,8 +10,6 @@
       <% end %>
     </div>
 
-  <div class="categories">
-    <h3>Categories</h3>
 
 
 <%# @resources.each do |resource| %>
@@ -20,16 +18,34 @@
   <%# </div> %>
 
 
+<div class="categories">
+    <h3>Categories</h3>
+      <%= simple_form_for :search, url: resources_path, method: "GET" do |f| %>
+        <% @tags.each do |tag|  %>
+          <div>
+            <%= check_box_tag "keywords[]", tag.name, @selected_tag.present? ? @selected_tag.include?(tag.name) : '' %>
+            <%= tag.name %>
+          </div>
+        <% end %>
+        <%= f.submit "Search", class: "btn btn-primary" %>
+          <%= link_to "Reset", resources_path  %>
+        <% end %>
+
+  </div>
 
 
-    <%# <%= simple_form_for @resources do |f| %>
-    <%# <%= f.input :categories,
+
+
+
+
+    <%#= simple_form_for @resources do |f| %>
+    <%#= f.input :categories,
               as: :radio_buttons,
               collection_wrapper_category: 'div',
               collection_wrapper_class: 'category-wrapper',
               item_wrapper_class: 'category-item',
               input_html: {class: 'category-selector'},
               collection: Snippet::CATEGORIES %>
-    <%# <% end %>
-  </div>
-</div>
+    <%# end %>
+  <%# </div>
+</div> %>

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -1,29 +1,23 @@
-<%# <div id="map" %>
-     <%# style="width: 100%; height: 100vh;"
-     data-markers="<#%= @markers.to_json %>"
-     <%# data-mapbox-api-key="<#%= ENV['MAPBOX_API_KEY'] %>
-<%# </div> %>
+<div id="map"
+    style="width: 100%; height: 100vh;"
+    data-markers="<%= @markers.to_json %>"
+    data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>">
+</div>
 
 
 <div id="main">
-        <% @resources.each do |resource| %>
-        <div class= "card m-2 p-2">
-          <div class= "resource_infos">
-              <p class="name"><%= resource.name %></p>
-              <p class="name"><%= resource.categories.pluck(:name).join(',') %></p>
-          </div>
-        </div>
-        <% end %>
-  <div id="top">
-  </div>
   <div id="bottom">
     <div id="lists">
       <div class="sidenav">
-
+        <% @resources.each do |resource| %>
+            <div class= "card m-2 p-2">
+              <div class= "resource_infos">
+                  <p class="name"><%= resource.name %></p>
+                  <p class="name"><%= resource.categories.pluck(:name).join(',') %></p>
+              </div>
+            </div>
+          <% end %>
       </div>
     </div>
   </div>
 </div>
-
-
-<%# <div id="geocoder" class="geocoder"></div> %>

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -1,23 +1,25 @@
-<div id="map"
-     style="width: 100%; height: 100vh;"
-     data-markers="<%= @markers.to_json %>"
-     data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>">
-</div>
+<%# <div id="map" %>
+     <%# style="width: 100%; height: 100vh;"
+     data-markers="<#%= @markers.to_json %>"
+     <%# data-mapbox-api-key="<#%= ENV['MAPBOX_API_KEY'] %>
+<%# </div> %>
 
 
 <div id="main">
+        <% @resources.each do |resource| %>
+        <div class= "card m-2 p-2">
+          <div class= "resource_infos">
+              <p class="name"><%= resource.name %></p>
+              <p class="name"><%= resource.categories.pluck(:name).join(',') %></p>
+          </div>
+        </div>
+        <% end %>
   <div id="top">
   </div>
   <div id="bottom">
     <div id="lists">
       <div class="sidenav">
-        <% @resources.each do |resource| %>
-        <div class= "card m-2 p-2">
-          <div class= "resource_infos">
-              <p class="name"><%= resource.name %></p>
-          </div>
-        </div>
-        <% end %>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR combines the location-based and category search into one single search form.

### Preview:
https://user-images.githubusercontent.com/48615972/149704776-ec41859c-2c37-471c-bb77-72af3c1faf30.mov

### What changed:
Previously, we had two separate forms, one for categories, one for location. This caused a problem where the params from the first performed search disappeared once the second search was triggered. 
This PR combines both categories and location-based search into one form so that users can find resources either by location, by category, or by both.

How does the location-based search work? Currently, we're returning resources that are within a 100km radius of the requested location. However, this can be adjusted by updating this code: `Resource.near(@location, 100)`

### To-do:
- [ ] Handle no results being returned - What do we want to display in this case? A message to the user and all the results again? A message to the user and an empty map? - Needs to be decided :) 
- [ ] Replace checkboxes with icons - can be handled in a separate branch and PR
- [ ] Clean up layout (spacing, sidebar cards, etc.)
