### PR TITLE
Added resources on navbar when on dashboard page only

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,6 +7,12 @@
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <% if user_signed_in? %>
+
+      <% if params[:controller] == 'dashboard' %>
+            <li class="nav-item">
+            <%= link_to t("Resources"), resources_path, class: "nav-link" %>
+          </li>
+        <% end %>
         <li class="nav-item">
           <%= link_to t("Add a Resource"), new_resource_path, class: "nav-link" %>
         </li>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87785320/150277777-d2442c92-862d-45b5-9bd8-9672b9f57930.png)

The resource only appears on navbar when it's on the Dashboard page. 